### PR TITLE
Allow parseHash to parse #/product?param=1

### DIFF
--- a/src/parser.fs
+++ b/src/parser.fs
@@ -348,12 +348,12 @@ let parsePath (parser:Parser<_,_>) (location:Location) =
 path entirely.
 *)
 let parseHash (parser:Parser<_,_>) (location:Location) =
-    let hash, search = 
-        (location.hash.Substring 1).Split([|"?"|], System.StringSplitOptions.RemoveEmptyEntries)
-        |> Array.truncate 2
-        |> function
-        | [|a|] -> a, "?"
-        | [|a;b|] -> a, "?"+b
-        | _ -> "", "?"   
+    let hash, search =
+        let hash = location.hash.Substring 1
+        if hash.Contains("?") then
+            let h = hash.Substring(0, hash.IndexOf("?"))
+            h, hash.Substring(h.Length)
+        else
+            hash, "?"
 
     parse parser (hash) (parseParams search)

--- a/src/parser.fs
+++ b/src/parser.fs
@@ -344,7 +344,7 @@ ignores the hash entirely.
 let parsePath (parser:Parser<_,_>) (location:Location) =
     parse parser location.pathname (parseParams location.search)
 
-(* Parse based on `location.hash`. This parser ignores the normal
+(** Parse based on `location.hash`. This parser ignores the normal
 path entirely.
 *)
 let parseHash (parser:Parser<_,_>) (location:Location) =

--- a/src/parser.fs
+++ b/src/parser.fs
@@ -344,9 +344,16 @@ ignores the hash entirely.
 let parsePath (parser:Parser<_,_>) (location:Location) =
     parse parser location.pathname (parseParams location.search)
 
-(** Parse based on `location.hash` and `location.search`. This parser
-ignores the normal path entirely.
+(* Parse based on `location.hash`. This parser ignores the normal
+path entirely.
 *)
 let parseHash (parser:Parser<_,_>) (location:Location) =
-    parse parser (location.hash.Substring 1) (parseParams location.search)
+    let hash, search = 
+        (location.hash.Substring 1).Split([|"?"|], System.StringSplitOptions.RemoveEmptyEntries)
+        |> Array.truncate 2
+        |> function
+        | [|a|] -> a, "?"
+        | [|a;b|] -> a, "?"+b
+        | _ -> "", "?"   
 
+    parse parser (hash) (parseParams search)


### PR DESCRIPTION
Using both location.hash and location.search means the currently the url has to be:

http://localhost/?param=1#/page

When it should really be

http://localhost/#/page?param=1



