### PR TITLE
Use Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+    <PropertyGroup>
+        <Description>Elmish extensions for Fable apps targeting web browsers</Description>
+        <PackageProjectUrl>http://fable-elmish.github.io/browser</PackageProjectUrl>
+        <PackageLicenseUrl>https://raw.githubusercontent.com/fable-elmish/browser/master/LICENSE.md</PackageLicenseUrl>
+        <PackageIconUrl>https://raw.githubusercontent.com/fable-elmish/elmish/master/docs/files/img/logo.png</PackageIconUrl>
+        <RepositoryUrl>https://github.com/fable-elmish/browser</RepositoryUrl>
+        <PackageTags>fable;elmish;fsharp</PackageTags>
+        <Authors>Eugene Tolmachev</Authors>
+    </PropertyGroup>
+    <Import Project="$(MSBuildThisFileDirectory)\Meta.props" Condition="exists('$(MSBuildThisFileDirectory)\Meta.props')" />
+</Project>

--- a/build.fsx
+++ b/build.fsx
@@ -53,17 +53,10 @@ Target "Build" (fun _ ->
 let release = LoadReleaseNotes "RELEASE_NOTES.md"
 
 Target "Meta" (fun _ ->
-    [ "<Project xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">"
-      "<PropertyGroup>"
-      "<Description>Elmish extensions for Fable apps targeting web browsers</Description>"
-      sprintf "<PackageProjectUrl>http://%s.github.io/%s</PackageProjectUrl>" gitOwner gitName
-      "<PackageLicenseUrl>https://raw.githubusercontent.com/fable-elmish/browser/master/LICENSE.md</PackageLicenseUrl>"
-      "<PackageIconUrl>https://raw.githubusercontent.com/fable-elmish/elmish/master/docs/files/img/logo.png</PackageIconUrl>"
-      sprintf "<RepositoryUrl>%s/%s</RepositoryUrl>" gitHome gitName
-      "<PackageTags>fable;elmish;fsharp</PackageTags>"
-      "<Authors>Eugene Tolmachev</Authors>"
-      sprintf "<Version>%s</Version>" (string release.SemVer)
-      "</PropertyGroup>"
+    [ "<Project>"
+      "    <PropertyGroup>"
+      sprintf "        <Version>%s</Version>" (string release.SemVer)
+      "    </PropertyGroup>"
       "</Project>"]
     |> WriteToFile false "Meta.props"
 )

--- a/src/Fable.Elmish.Browser.fsproj
+++ b/src/Fable.Elmish.Browser.fsproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\Meta.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
More of a proposal than anything as the previous version works well. This use `Directory.Build.props` special name so there is not need for a direct import and except for the version all properties are already there even if the build script isn't called (And `Meta.props` not generated)