### PR TITLE
Solved TryParse overload ambiguity

### DIFF
--- a/src/parser.fs
+++ b/src/parser.fs
@@ -268,7 +268,7 @@ let stringParam name =
 
 let internal intParamHelp =
     Option.bind 
-        (fun value ->
+        (fun (value : string) ->
             match System.Int32.TryParse value with
             | (true,x) -> Some x
             | _ -> None)


### PR DESCRIPTION
I retargeted my app from _netcoreapp2.0_ to _netcoreapp2.1_ and started to get here:
`A unique overload for method 'TryParse' could not be determined based on type information prior to this program point. A type annotation may be needed. Candidates: System.Int32.TryParse(s: System.ReadOnlySpan<char>, result: byref<int>) : bool, System.Int32.TryParse(s: string, result: byref<int>) : bool`

This change fixes the error.