### PR TITLE
Don't use typed window.addEventListener_XXX methods

### DIFF
--- a/src/navigation.fs
+++ b/src/navigation.fs
@@ -67,8 +67,8 @@ module Program =
 
             onChangeRef <- onChange
 
-            window.addEventListener_popstate(unbox onChangeRef)
-            window.addEventListener_hashchange(unbox onChangeRef)
+            window.addEventListener("popstate", unbox onChangeRef)
+            window.addEventListener("hashchange", unbox onChangeRef)
             window.addEventListener(Navigation.NavigatedEvent, unbox onChangeRef)
 
         let unsubscribe () =


### PR DESCRIPTION
I've noticed that the Fable.Import.Browser.dll is responsible for a big part of the time spent during Fable's REPL startup due to its size, so I'm trying to trim it down. This means removing also the auto-generated methods to type the first argument in APIs like `window.addEventListener`.