### PR TITLE
Use decodeURIComponent for query params

### DIFF
--- a/src/parser.fs
+++ b/src/parser.fs
@@ -324,7 +324,7 @@ open Fable.Core
 let internal toKeyValuePair (segment: string) =
     match segment.Split('=') with
     | [| key; value |] ->
-        Option.tuple (Option.ofFunc JS.decodeURI key) (Option.ofFunc JS.decodeURI value)
+        Option.tuple (Option.ofFunc JS.decodeURIComponent key) (Option.ofFunc JS.decodeURIComponent value)
     | _ -> None
 
 


### PR DESCRIPTION
`decodeURIComponent` should be used when decoding the key and values of query params.

```js
var test = ""foo%2Bbar";

decodeURI(test) // "foo%2Bbar"
decodeURIComponent(test) // "foo+bar"
```