### PR TITLE
Clarified usage of init function in Routing docs

### DIFF
--- a/docs/content/routing.fsx
+++ b/docs/content/routing.fsx
@@ -41,7 +41,7 @@ Normally you want to put many of these parsers together to handle all possible r
 
 *)
 
-type Route = Blog of int | Search of string
+type Route = Blog of int | Search of string | Home
 
 let route =
     oneOf
@@ -107,10 +107,16 @@ let urlUpdate (result:Option<Route>) model =
 It looks like `update` function but instead of the message it handles the route changes.
 If the URL is valid, we just update our model or issue a command, otherwise we modify the URL to whatever makes sense.
 
+We will also need to modify our init function so that it takes the route as an argument; usually it defaults to `unit` if routing is not used.
+*)
+open Elmish
+
+let init (initialRoute:Option<Route>) =
+  ({ route = initialRoute |> Option.defaultValue Home; query = "" }, Cmd.Empty)
+
+(**
 Now we augument our program instance with Navigation capabilities, passing the parser and `urlUpdate`:
 *)
-
-open Elmish
 
 Program.mkProgram init update view
 |> Program.toNavigable (parseHash route) urlUpdate


### PR DESCRIPTION
I was following the documentation and I struggled for a while trying to figure out why my code refused to compile but as far as I could see, I'd followed the tutorial to the letter!

Turns out that one's `init` function usually takes `unit` and using `Program.toNavigable` means it now needs to take the initial route value instead!

I've added this requirement to the doco so the next person doesn't spin their wheels like I did. I added a `Home` case to the `Route` type to give the `init` function something to fall back to in the case where the initial route fails to parse.