### PR TITLE
Fix broken link

### DIFF
--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -41,7 +41,7 @@ Program.mkProgram init update view
 |> Program.run
 
 (**
-For more information see the [routing tutorial](routing.html).
+For more information see the [routing tutorial](tutorials/routing.html).
 
 ### Navigation
 Manipulate the browser's navigation and history.


### PR DESCRIPTION
While searching for routing documentation I noticed a broken link on [this page](https://elmish.github.io/browser/). I think it should go to [https://elmish.github.io/browser/tutorials/routing.html](https://elmish.github.io/browser/tutorials/routing.html).