### PR TITLE
bump Fable.Browser.Dom ver to 2.*

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 4.0.0-beta-6
+* Bump Fable.Browser.Dom dependency to 2.*
+
 ## 4.0.0-beta-5
 
 * Release `Browser.console` logger impl, thanks Alfonso and Alberto De Pena

--- a/src/Fable.Elmish.Browser.fsproj
+++ b/src/Fable.Elmish.Browser.fsproj
@@ -11,7 +11,7 @@
     <Content Include="*.fsproj; *.fs" PackagePath="fable\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Browser.Dom" Version="1.*" />
+    <PackageReference Include="Fable.Browser.Dom" Version="2.*" />
     <PackageReference Include="Fable.Elmish" Version="4.0.0-beta-*" />
     <PackageReference Include="Fable.Elmish.UrlParser" Version="1.0.0-beta-*" />
   </ItemGroup>


### PR DESCRIPTION
At some point 1.* was broken and I had a weird situation where solution that used to compile was failing with breaking on invalid JS after the compilation. V2 doesn't seem to have any problems atm.