### PR TITLE
Add subIds param to Tracers.console

### DIFF
--- a/src/tracers.fs
+++ b/src/tracers.fs
@@ -1,5 +1,5 @@
 [<RequireQualifiedAccess>]
-module Elmish.Tracers 
+module Elmish.Tracers
 
 open System
 open Fable.Core
@@ -37,6 +37,6 @@ let getMsgNameAndFields (t: Type) (x: 'Msg) : string * obj =
 
 /// Use it when initializing your Elmish app like this
 /// |> Program.withTrace Tracers.console
-let inline console (msg: 'Msg) (_state: 'State) =
-    let msg, fields = getMsgNameAndFields typeof<'Msg> msg
+let inline console (msg: 'Msg) (_state: 'State) (_subId: SubId list) =
+    let msg, fields = getMsgNameAndFields typedefof<'Msg> msg
     JS.console.log (msg, fields)

--- a/src/tracers.fs
+++ b/src/tracers.fs
@@ -38,5 +38,5 @@ let getMsgNameAndFields (t: Type) (x: 'Msg) : string * obj =
 /// Use it when initializing your Elmish app like this
 /// |> Program.withTrace Tracers.console
 let inline console (msg: 'Msg) (_state: 'State) (_subId: SubId list) =
-    let msg, fields = getMsgNameAndFields typedefof<'Msg> msg
+    let msg, fields = getMsgNameAndFields typeof<'Msg> msg
     JS.console.log (msg, fields)


### PR DESCRIPTION
Fixes bug #59 

Release 4.0.0 requires the extra `(subId: SubId list)` parameter.

@alfonsogarciacaro 

Should we also log the `(subId: SubId list)` changes? `withConsoleTrace` already does it but since we do not log `Model` changes just wanted to run it by you...